### PR TITLE
Add docker upload command

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,6 +54,13 @@ jobs:
           go-version: 1.19
           cache: true
 
+      - name: Login to docker registry (yehudac.jfrog.io)
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: yehudac.jfrog.io
+          username: ${{ secrets.JFROG_USERNAME }}
+          password: ${{ secrets.JFROG_PASSWORD }}
+
       - name: Run unit tests
         run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LINT_NOT_INSTALLED_MESSAGE := "$(LINT) is not installed ❌\nPlease visit https:
 ENTRYPOINT := ./cmd/bring
 BUILD_OUTPUT := bring
 COVERAGE_FILE := coverage.txt
-CLEANUP_FILES := $(BUILD_OUTPUT) $(COVERAGE_FILE)
+CLEANUP_FILES := $(BUILD_OUTPUT) $(COVERAGE_FILE) ./integration/testdata/images/*
 TEST_PARALLEL := 10
 
 .PHONY: all
@@ -38,6 +38,7 @@ test:
 
 .PHONY: integration-tests
 integration-tests:
+	./scripts/download-images.sh
 	$(GO) test -v -parallel $(TEST_PARALLEL) -tags=integration ./integration/...
 
 .PHONY: install

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ endif
 
 .PHONY: lint
 lint:
-	golangci-lint run
+	$(LINT) run
 
 .PHONY: build
 build:

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -7,6 +7,13 @@ import (
 	"testing"
 )
 
+const (
+	singleImageBundle      = "testdata/images/single.tar"
+	multipleImageBundle    = "testdata/images/multiple.tar"
+	invalidImageBundle     = "testdata/images/invalid.tar"
+	nonexistentImageBundle = "testdata/images/nonexistent.tar"
+)
+
 func buildDownloadArgs(images []string, path string) []string {
 	args := append([]string{"docker", "download"}, images...)
 
@@ -47,13 +54,13 @@ func TestDockerDownload(t *testing.T) {
 	}{
 		{
 			name:            "Should succeed - single image",
-			fields:          fields{images: []string{"alpine:3.16.2"}, path: "/tmp/single.tar"},
+			fields:          fields{images: []string{"alpine:3.16.2"}, path: singleImageBundle},
 			wantErr:         false,
 			wantHelpMessage: false,
 		},
 		{
 			name:            "Should succeed - multiple images",
-			fields:          fields{images: []string{"alpine:3.16.2", "redis:7.0.5-alpine"}, path: "/tmp/multiple.tar"},
+			fields:          fields{images: []string{"alpine:3.16.2", "redis:7.0.5-alpine"}, path: multipleImageBundle},
 			wantErr:         false,
 			wantHelpMessage: false,
 		},
@@ -117,25 +124,25 @@ func TestDockerUpload(t *testing.T) {
 	}{
 		{
 			name:            "Should succeed - single image bundle",
-			fields:          fields{path: "/tmp/single.tar", destination: "yehudac.jfrog.io/example"},
+			fields:          fields{path: singleImageBundle, destination: "yehudac.jfrog.io/example"},
 			wantErr:         false,
 			wantHelpMessage: false,
 		},
 		{
 			name:            "Should succeed - multiple images",
-			fields:          fields{path: "/tmp/multiple.tar", destination: "yehudac.jfrog.io/example"},
+			fields:          fields{path: multipleImageBundle, destination: "yehudac.jfrog.io/example"},
 			wantErr:         false,
 			wantHelpMessage: false,
 		},
 		{
 			name:            "Should succeed - single image, target subpath",
-			fields:          fields{path: "/tmp/single.tar", destination: "yehudac.jfrog.io/example/subpath"},
+			fields:          fields{path: singleImageBundle, destination: "yehudac.jfrog.io/example/subpath"},
 			wantErr:         false,
 			wantHelpMessage: false,
 		},
 		{
 			name:            "Should succeed - multiple images, target subpath",
-			fields:          fields{path: "/tmp/multiple.tar", destination: "yehudac.jfrog.io/example/subpath"},
+			fields:          fields{path: multipleImageBundle, destination: "yehudac.jfrog.io/example/subpath"},
 			wantErr:         false,
 			wantHelpMessage: false,
 		},
@@ -147,31 +154,31 @@ func TestDockerUpload(t *testing.T) {
 		},
 		{
 			name:            "Should fail - no target given",
-			fields:          fields{path: "/tmp/single.tar"},
+			fields:          fields{path: singleImageBundle},
 			wantErr:         true,
 			wantHelpMessage: true,
 		},
 		{
 			name:            "Should fail - invalid input file",
-			fields:          fields{path: "/tmp/invalid.tar", destination: "yehudac.jfrog.io/example"},
+			fields:          fields{path: invalidImageBundle, destination: "yehudac.jfrog.io/example"},
 			wantErr:         true,
 			wantHelpMessage: false,
 		},
 		{
 			name:            "Should fail - input file not found",
-			fields:          fields{path: "/tmp/not/exists/bundle.tar", destination: "yehudac.jfrog.io/example"},
+			fields:          fields{path: nonexistentImageBundle, destination: "yehudac.jfrog.io/example"},
 			wantErr:         true,
 			wantHelpMessage: false,
 		},
 		{
 			name:            "Should fail - registry not found",
-			fields:          fields{path: "/tmp/single.tar", destination: "somenonexistentregistry.io/iyehuda"},
+			fields:          fields{path: singleImageBundle, destination: "somenonexistentregistry.io/iyehuda"},
 			wantErr:         true,
 			wantHelpMessage: false,
 		},
 		{
 			name:            "Should fail - registry path not found",
-			fields:          fields{path: "/tmp/single.tar", destination: "yehudac.jfrog.io/restricted"},
+			fields:          fields{path: singleImageBundle, destination: "yehudac.jfrog.io/restricted"},
 			wantErr:         true,
 			wantHelpMessage: false,
 		},

--- a/integration/docker_test.go
+++ b/integration/docker_test.go
@@ -4,6 +4,7 @@ package integration
 
 import (
 	"bytes"
+	"path"
 	"testing"
 )
 
@@ -46,6 +47,8 @@ func TestDockerDownload(t *testing.T) {
 		path   string
 	}
 
+	tempDir := t.TempDir()
+
 	tests := []struct {
 		name            string
 		fields          fields
@@ -54,13 +57,13 @@ func TestDockerDownload(t *testing.T) {
 	}{
 		{
 			name:            "Should succeed - single image",
-			fields:          fields{images: []string{"alpine:3.16.2"}, path: singleImageBundle},
+			fields:          fields{images: []string{"busybox:1.35.0"}, path: path.Join(tempDir, "single.tar")},
 			wantErr:         false,
 			wantHelpMessage: false,
 		},
 		{
 			name:            "Should succeed - multiple images",
-			fields:          fields{images: []string{"alpine:3.16.2", "redis:7.0.5-alpine"}, path: multipleImageBundle},
+			fields:          fields{images: []string{"alpine:3.16.2", "busybox:1.35.0"}, path: path.Join(tempDir, "multiple.tar")},
 			wantErr:         false,
 			wantHelpMessage: false,
 		},
@@ -72,19 +75,19 @@ func TestDockerDownload(t *testing.T) {
 		},
 		{
 			name:            "Should fail - no target given",
-			fields:          fields{images: []string{"alpine:3.16.2", "redis:7.0.5-alpine"}},
+			fields:          fields{images: []string{"alpine:3.16.2", "busybox:1.35.0"}},
 			wantErr:         true,
 			wantHelpMessage: true,
 		},
 		{
 			name:            "Should fail - image not found",
-			fields:          fields{images: []string{"iyehuda/not:exists"}, path: "/tmp/a"},
+			fields:          fields{images: []string{"iyehuda/not:exists"}, path: path.Join(tempDir, "output.tar")},
 			wantErr:         true,
 			wantHelpMessage: false,
 		},
 		{
 			name:            "Should fail - target path not found",
-			fields:          fields{images: []string{"alpine:3.16.2"}, path: "/tmp/not/exists"},
+			fields:          fields{images: []string{"busybox:1.35.0"}, path: path.Join(tempDir, "not/exists.tar")},
 			wantErr:         true,
 			wantHelpMessage: false,
 		},

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -72,6 +72,6 @@ func assertContainsIf(t *testing.T, buf *bytes.Buffer, substr string, condition 
 	}
 }
 
-func assertErrorPrintedIf(t *testing.T, buf *bytes.Buffer, condition bool) {
+func assertUsagePrintedIf(t *testing.T, buf *bytes.Buffer, condition bool) {
 	assertContainsIf(t, buf, helpMessage, condition)
 }

--- a/misc/util.py
+++ b/misc/util.py
@@ -1,0 +1,33 @@
+def generate_retag_test_cases():
+    sources = [
+        ("alpine", "Docker Hub (official, no tag)"),
+        ("alpine:3.16.2", "Docker Hub (official, with tag)"),
+        ("nested/alpine", "Docker Hub (community, no tag)"),
+        ("nested/alpine:3.16.2", "Docker Hub (community, with tag)"),
+        ("quay.io/alpine", "private registry (flat, no tag)"),
+        ("quay.io/alpine:3.16.2", "private registry (flat, with tag)"),
+        ("quay.io/nested/alpine", "private registry (nested, no tag)"),
+        ("quay.io/nested/alpine:3.16.2", "private registry (nested, with tag)"),
+    ]
+
+    destinations = [
+        ("example", "Docker Hub (community)"),
+        ("gcr.io", "private registry (naked)"),
+        ("gcr.io/example", "private registry (flat)"),
+        ("gcr.io/example/images", "private registry (nested)"),
+    ]
+
+    for destination, destination_description in destinations:
+        for source, source_description in sources:
+            print(
+                f"""        {'{'}
+            name: "from {source_description} to {destination_description}",
+            source: "{source}",
+            target: "{destination}",
+            want: "{destination}/{source.split('/', 1)[-1]}",
+        {'}'},"""
+            )
+
+
+if __name__ == "__main__":
+    generate_retag_test_cases()

--- a/pkg/commands/docker/docker.go
+++ b/pkg/commands/docker/docker.go
@@ -12,6 +12,7 @@ func NewCommand() *cobra.Command {
 
 	command.AddCommand(
 		NewDownloadCommand(),
+		NewUploadCommand(),
 	)
 
 	return command

--- a/pkg/commands/docker/download.go
+++ b/pkg/commands/docker/download.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/iyehuda/bring/pkg/docker"
-	"github.com/iyehuda/bring/pkg/utils/commands"
+	"github.com/iyehuda/bring/pkg/executils"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +46,7 @@ func validateDownloadArgs(opts *downloadOptions) func(cmd *cobra.Command, args [
 
 func downloadImages(opts *downloadOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		fetcher := docker.NewFetcher(args, opts.downloadTarget, &commands.LocalRunner{})
+		fetcher := docker.NewFetcher(args, opts.downloadTarget, &executils.LocalRunner{})
 
 		if err := fetcher.Fetch(); err != nil {
 			return fmt.Errorf("failed to download images: %w", err)

--- a/pkg/commands/docker/download.go
+++ b/pkg/commands/docker/download.go
@@ -46,9 +46,9 @@ func validateDownloadArgs(opts *downloadOptions) func(cmd *cobra.Command, args [
 
 func downloadImages(opts *downloadOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		docker := docker.NewFetcher(args, opts.downloadTarget, &commands.LocalRunner{})
+		fetcher := docker.NewFetcher(args, opts.downloadTarget, &commands.LocalRunner{})
 
-		if err := docker.Fetch(); err != nil {
+		if err := fetcher.Fetch(); err != nil {
 			return fmt.Errorf("failed to download images: %w", err)
 		}
 

--- a/pkg/commands/docker/upload.go
+++ b/pkg/commands/docker/upload.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/iyehuda/bring/pkg/docker"
-	"github.com/iyehuda/bring/pkg/utils/commands"
+	"github.com/iyehuda/bring/pkg/executils"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +49,7 @@ func validateUploadArgs(opts *uploadOptions) func(cmd *cobra.Command, args []str
 func uploadImages(opts *uploadOptions) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		retagger := docker.NewPreservePathImageRetagger(opts.uploadTarget)
-		uploader := docker.NewImageUploader(retagger, &commands.LocalRunner{})
+		uploader := docker.NewImageUploader(retagger, &executils.LocalRunner{})
 
 		images, err := uploader.UploadImages(args[0])
 		if err != nil {

--- a/pkg/commands/docker/upload.go
+++ b/pkg/commands/docker/upload.go
@@ -1,0 +1,63 @@
+package docker
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/iyehuda/bring/pkg/docker"
+	"github.com/iyehuda/bring/pkg/utils/commands"
+	"github.com/spf13/cobra"
+)
+
+var errUploadTargetNotSet = errors.New("please specify an upload target")
+
+type uploadOptions struct {
+	uploadTarget string
+}
+
+// NewUploadCommand creates new docker upload command for extracting images from archive file,
+// re-tagging, and pushing them to docker registry.
+func NewUploadCommand() *cobra.Command {
+	opts := &uploadOptions{}
+	cmd := &cobra.Command{
+		Use:     "upload <archive file> --to <target registry>",
+		Short:   "Upload a set of docker images from an archive file",
+		Long:    `This command depends on having docker installed and logged in to your registry (if necessary).`,
+		PreRunE: validateUploadArgs(opts),
+		RunE:    uploadImages(opts),
+		Args:    cobra.ExactArgs(1),
+	}
+
+	cmd.Flags().StringVar(&opts.uploadTarget, "to", "", "target registry to upload (e.g. 'quay.io/iyehuda', 'quay.io/iyehuda/subpath', etc.)")
+
+	return cmd
+}
+
+func validateUploadArgs(opts *uploadOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if opts.uploadTarget == "" {
+			return errUploadTargetNotSet
+		}
+
+		cmd.SilenceUsage = true
+
+		return nil
+	}
+}
+
+func uploadImages(opts *uploadOptions) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		retagger := docker.NewPreservePathImageRetagger(opts.uploadTarget)
+		uploader := docker.NewImageUploader(retagger, &commands.LocalRunner{})
+
+		images, err := uploader.UploadImages(args[0])
+		if err != nil {
+			return fmt.Errorf("failed to upload images: %w", err)
+		}
+
+		cmd.Printf("Uploaded images:\n%s\n", strings.Join(images, "\n"))
+
+		return nil
+	}
+}

--- a/pkg/docker/fetcher.go
+++ b/pkg/docker/fetcher.go
@@ -5,18 +5,18 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/iyehuda/bring/pkg/utils/commands"
+	"github.com/iyehuda/bring/pkg/executils"
 )
 
 // Fetcher enables to fetch docker images from registry and save them locally.
 type Fetcher struct {
 	images      []string
 	destination string
-	runner      commands.Runner
+	runner      executils.Runner
 }
 
 // NewFetcher creates new instance of Fetcher with image list and destination file path.
-func NewFetcher(images []string, destination string, runner commands.Runner) *Fetcher {
+func NewFetcher(images []string, destination string, runner executils.Runner) *Fetcher {
 	return &Fetcher{
 		images:      images,
 		destination: destination,

--- a/pkg/docker/fetcher_test.go
+++ b/pkg/docker/fetcher_test.go
@@ -3,8 +3,8 @@ package docker
 import (
 	"testing"
 
-	"github.com/iyehuda/bring/pkg/utils/commands"
-	"github.com/iyehuda/bring/pkg/utils/tests"
+	"github.com/iyehuda/bring/pkg/executils"
+	"github.com/iyehuda/bring/pkg/testutils"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -14,20 +14,20 @@ func TestFetcher_Fetch(t *testing.T) {
 	type fields struct {
 		images      []string
 		destination string
-		runner      commands.Runner
+		runner      executils.Runner
 	}
 
-	failOnPull := new(tests.MockCommandRunner)
-	failOnPull.On("Run", mock.MatchedBy(tests.CommandIncludes("docker pull"))).
+	failOnPull := new(testutils.MockCommandRunner)
+	failOnPull.On("Run", mock.MatchedBy(testutils.CommandIncludes("docker pull"))).
 		Return(&ImagePullError{Image: "alpine:not-exists", Err: nil})
 
-	failOnSave := new(tests.MockCommandRunner)
-	failOnSave.On("Run", mock.MatchedBy(tests.CommandIncludes("docker pull"))).
+	failOnSave := new(testutils.MockCommandRunner)
+	failOnSave.On("Run", mock.MatchedBy(testutils.CommandIncludes("docker pull"))).
 		Return(nil)
-	failOnSave.On("Run", mock.MatchedBy(tests.CommandIncludes("docker save"))).
+	failOnSave.On("Run", mock.MatchedBy(testutils.CommandIncludes("docker save"))).
 		Return(&ImageSaveError{Images: []string{"alpine:3.16"}, Destination: "/foo/bar", Err: nil})
 
-	noOpCommandRunner := &tests.FakeCommandRunner{}
+	noOpCommandRunner := &testutils.FakeCommandRunner{}
 
 	tests := []struct {
 		name    string

--- a/pkg/docker/ratgger.go
+++ b/pkg/docker/ratgger.go
@@ -1,0 +1,32 @@
+package docker
+
+import (
+	"fmt"
+	"strings"
+)
+
+type PreservePathImageRetagger struct {
+	prefix string
+}
+
+func NewPreservePathImageRetagger(prefix string) *PreservePathImageRetagger {
+	return &PreservePathImageRetagger{
+		prefix: prefix,
+	}
+}
+
+func stripRegistryFromImage(image string) string {
+	registry, relativeName, ok := strings.Cut(image, "/")
+
+	if !ok || !strings.ContainsAny(registry, ".:") {
+		return image
+	}
+
+	return relativeName
+}
+
+func (ir *PreservePathImageRetagger) Retag(image string) string {
+	relativeName := stripRegistryFromImage(image)
+
+	return fmt.Sprintf("%s/%s", ir.prefix, relativeName)
+}

--- a/pkg/docker/ratgger.go
+++ b/pkg/docker/ratgger.go
@@ -5,10 +5,21 @@ import (
 	"strings"
 )
 
+// PreservePathImageRetagger enables to re-tag a docker image under a different registry target.
+// The re-tagging preserves the source relative path under the source registry and appends it to the target path.
+// Examples:
+//
+//	r := NewPreservePathImageRetagger("quay.io/iyehuda")
+//	r.Retag("alpine:3.16.2") // would give "quay.io/iyehuda/alpine:3.16.2"
+//	r.Retag("grafana/grafana:latest") // would give "quay.io/iyehuda/grafana/grafana:latest"
+//
+//	r := NewPreservePathImageRetagger("yehudac.jfrog.io/my/images")
+//	r.Retag("quay.io/argoproj/argocd:2.3.4") // would give "yehudac.jfrog.io/my/images/argoproj/argocd:2.3.4"
 type PreservePathImageRetagger struct {
 	prefix string
 }
 
+// NewPreservePathImageRetagger creates a new PreservePathImageRetagger with the given registry prefix.
 func NewPreservePathImageRetagger(prefix string) *PreservePathImageRetagger {
 	return &PreservePathImageRetagger{
 		prefix: prefix,
@@ -25,6 +36,9 @@ func stripRegistryFromImage(image string) string {
 	return relativeName
 }
 
+// Retag takes an image and returns its new name under the retagger prefix.
+// The image parameter could be any legal docker image name.
+// The output will preserve the original image relative path under its registry.
 func (ir *PreservePathImageRetagger) Retag(image string) string {
 	relativeName := stripRegistryFromImage(image)
 

--- a/pkg/docker/ratgger_test.go
+++ b/pkg/docker/ratgger_test.go
@@ -1,0 +1,220 @@
+package docker
+
+import "testing"
+
+func TestPreservePathImageRetagger_Retag(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source string
+		target string
+		want   string
+	}{
+		{
+			name:   "from Docker Hub (official, no tag) to Docker Hub (community)",
+			source: "alpine",
+			target: "example",
+			want:   "example/alpine",
+		},
+		{
+			name:   "from Docker Hub (official, with tag) to Docker Hub (community)",
+			source: "alpine:3.16.2",
+			target: "example",
+			want:   "example/alpine:3.16.2",
+		},
+		{
+			name:   "from Docker Hub (community, no tag) to Docker Hub (community)",
+			source: "nested/alpine",
+			target: "example",
+			want:   "example/nested/alpine",
+		},
+		{
+			name:   "from Docker Hub (community, with tag) to Docker Hub (community)",
+			source: "nested/alpine:3.16.2",
+			target: "example",
+			want:   "example/nested/alpine:3.16.2",
+		},
+		{
+			name:   "from private registry (flat, no tag) to Docker Hub (community)",
+			source: "quay.io/alpine",
+			target: "example",
+			want:   "example/alpine",
+		},
+		{
+			name:   "from private registry (flat, with tag) to Docker Hub (community)",
+			source: "quay.io/alpine:3.16.2",
+			target: "example",
+			want:   "example/alpine:3.16.2",
+		},
+		{
+			name:   "from private registry (nested, no tag) to Docker Hub (community)",
+			source: "quay.io/nested/alpine",
+			target: "example",
+			want:   "example/nested/alpine",
+		},
+		{
+			name:   "from private registry (nested, with tag) to Docker Hub (community)",
+			source: "quay.io/nested/alpine:3.16.2",
+			target: "example",
+			want:   "example/nested/alpine:3.16.2",
+		},
+		{
+			name:   "from Docker Hub (official, no tag) to private registry (naked)",
+			source: "alpine",
+			target: "gcr.io",
+			want:   "gcr.io/alpine",
+		},
+		{
+			name:   "from Docker Hub (official, with tag) to private registry (naked)",
+			source: "alpine:3.16.2",
+			target: "gcr.io",
+			want:   "gcr.io/alpine:3.16.2",
+		},
+		{
+			name:   "from Docker Hub (community, no tag) to private registry (naked)",
+			source: "nested/alpine",
+			target: "gcr.io",
+			want:   "gcr.io/nested/alpine",
+		},
+		{
+			name:   "from Docker Hub (community, with tag) to private registry (naked)",
+			source: "nested/alpine:3.16.2",
+			target: "gcr.io",
+			want:   "gcr.io/nested/alpine:3.16.2",
+		},
+		{
+			name:   "from private registry (flat, no tag) to private registry (naked)",
+			source: "quay.io/alpine",
+			target: "gcr.io",
+			want:   "gcr.io/alpine",
+		},
+		{
+			name:   "from private registry (flat, with tag) to private registry (naked)",
+			source: "quay.io/alpine:3.16.2",
+			target: "gcr.io",
+			want:   "gcr.io/alpine:3.16.2",
+		},
+		{
+			name:   "from private registry (nested, no tag) to private registry (naked)",
+			source: "quay.io/nested/alpine",
+			target: "gcr.io",
+			want:   "gcr.io/nested/alpine",
+		},
+		{
+			name:   "from private registry (nested, with tag) to private registry (naked)",
+			source: "quay.io/nested/alpine:3.16.2",
+			target: "gcr.io",
+			want:   "gcr.io/nested/alpine:3.16.2",
+		},
+		{
+			name:   "from Docker Hub (official, no tag) to private registry (flat)",
+			source: "alpine",
+			target: "gcr.io/example",
+			want:   "gcr.io/example/alpine",
+		},
+		{
+			name:   "from Docker Hub (official, with tag) to private registry (flat)",
+			source: "alpine:3.16.2",
+			target: "gcr.io/example",
+			want:   "gcr.io/example/alpine:3.16.2",
+		},
+		{
+			name:   "from Docker Hub (community, no tag) to private registry (flat)",
+			source: "nested/alpine",
+			target: "gcr.io/example",
+			want:   "gcr.io/example/nested/alpine",
+		},
+		{
+			name:   "from Docker Hub (community, with tag) to private registry (flat)",
+			source: "nested/alpine:3.16.2",
+			target: "gcr.io/example",
+			want:   "gcr.io/example/nested/alpine:3.16.2",
+		},
+		{
+			name:   "from private registry (flat, no tag) to private registry (flat)",
+			source: "quay.io/alpine",
+			target: "gcr.io/example",
+			want:   "gcr.io/example/alpine",
+		},
+		{
+			name:   "from private registry (flat, with tag) to private registry (flat)",
+			source: "quay.io/alpine:3.16.2",
+			target: "gcr.io/example",
+			want:   "gcr.io/example/alpine:3.16.2",
+		},
+		{
+			name:   "from private registry (nested, no tag) to private registry (flat)",
+			source: "quay.io/nested/alpine",
+			target: "gcr.io/example",
+			want:   "gcr.io/example/nested/alpine",
+		},
+		{
+			name:   "from private registry (nested, with tag) to private registry (flat)",
+			source: "quay.io/nested/alpine:3.16.2",
+			target: "gcr.io/example",
+			want:   "gcr.io/example/nested/alpine:3.16.2",
+		},
+		{
+			name:   "from Docker Hub (official, no tag) to private registry (nested)",
+			source: "alpine",
+			target: "gcr.io/example/images",
+			want:   "gcr.io/example/images/alpine",
+		},
+		{
+			name:   "from Docker Hub (official, with tag) to private registry (nested)",
+			source: "alpine:3.16.2",
+			target: "gcr.io/example/images",
+			want:   "gcr.io/example/images/alpine:3.16.2",
+		},
+		{
+			name:   "from Docker Hub (community, no tag) to private registry (nested)",
+			source: "nested/alpine",
+			target: "gcr.io/example/images",
+			want:   "gcr.io/example/images/nested/alpine",
+		},
+		{
+			name:   "from Docker Hub (community, with tag) to private registry (nested)",
+			source: "nested/alpine:3.16.2",
+			target: "gcr.io/example/images",
+			want:   "gcr.io/example/images/nested/alpine:3.16.2",
+		},
+		{
+			name:   "from private registry (flat, no tag) to private registry (nested)",
+			source: "quay.io/alpine",
+			target: "gcr.io/example/images",
+			want:   "gcr.io/example/images/alpine",
+		},
+		{
+			name:   "from private registry (flat, with tag) to private registry (nested)",
+			source: "quay.io/alpine:3.16.2",
+			target: "gcr.io/example/images",
+			want:   "gcr.io/example/images/alpine:3.16.2",
+		},
+		{
+			name:   "from private registry (nested, no tag) to private registry (nested)",
+			source: "quay.io/nested/alpine",
+			target: "gcr.io/example/images",
+			want:   "gcr.io/example/images/nested/alpine",
+		},
+		{
+			name:   "from private registry (nested, with tag) to private registry (nested)",
+			source: "quay.io/nested/alpine:3.16.2",
+			target: "gcr.io/example/images",
+			want:   "gcr.io/example/images/nested/alpine:3.16.2",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ir := &PreservePathImageRetagger{
+				prefix: tt.target,
+			}
+			if got := ir.Retag(tt.source); got != tt.want {
+				t.Errorf("ImageRetagger.Retag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/docker/uploader.go
+++ b/pkg/docker/uploader.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/iyehuda/bring/pkg/utils/commands"
+	"github.com/iyehuda/bring/pkg/executils"
 )
 
 // ImageRetagger is an interface that is able to get an image name and return a modified version of it.
@@ -18,11 +18,11 @@ type ImageRetagger interface {
 // ImageUploader is able to load an image bundle, retag its contents and upload it to a specified registry target.
 type ImageUploader struct {
 	retagger ImageRetagger
-	runner   commands.Runner
+	runner   executils.Runner
 }
 
 // NewImageUploader creates a new ImageUploader with a retagger and command runner.
-func NewImageUploader(retagger ImageRetagger, runner commands.Runner) *ImageUploader {
+func NewImageUploader(retagger ImageRetagger, runner executils.Runner) *ImageUploader {
 	return &ImageUploader{retagger: retagger, runner: runner}
 }
 

--- a/pkg/docker/uploader.go
+++ b/pkg/docker/uploader.go
@@ -1,0 +1,91 @@
+package docker
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+
+	"github.com/iyehuda/bring/pkg/utils/commands"
+)
+
+type ImageRetagger interface {
+	Retag(string) string
+}
+
+type ImageUploader struct {
+	retagger ImageRetagger
+	runner   commands.Runner
+}
+
+func NewImageUploader(retagger ImageRetagger, runner commands.Runner) *ImageUploader {
+	return &ImageUploader{retagger: retagger, runner: runner}
+}
+
+func (iu *ImageUploader) loadImageBundle(bundlePath string) ([]string, error) {
+	cmd := exec.Command("docker", "load", "--input", bundlePath)
+	output := &bytes.Buffer{}
+	cmd.Stderr = io.Discard
+	cmd.Stdout = output
+
+	if err := iu.runner.Run(cmd); err != nil {
+		return nil, fmt.Errorf("failed to run `docker load --input %s`: %w", bundlePath, err)
+	}
+
+	rawOutput := strings.TrimSpace(output.String())
+	lines := strings.Split(rawOutput, "\n")
+	loadedImages := make([]string, len(lines))
+
+	for i, line := range lines {
+		loadedImages[i] = strings.TrimPrefix(line, "Loaded image: ")
+	}
+
+	return loadedImages, nil
+}
+
+func (iu *ImageUploader) retagImage(oldImage string) (string, error) {
+	newName := iu.retagger.Retag(oldImage)
+
+	cmd := exec.Command("docker", "tag", oldImage, newName)
+	if err := iu.runner.Run(cmd); err != nil {
+		return "", fmt.Errorf("failed to run `docker tag %s %s`: %w", oldImage, newName, err)
+	}
+
+	return newName, nil
+}
+
+func (iu *ImageUploader) pushImage(image string) error {
+	cmd := exec.Command("docker", "push", image)
+	if err := iu.runner.Run(cmd); err != nil {
+		return fmt.Errorf("failed to run `docker push %s`: %w", image, err)
+	}
+
+	return nil
+}
+
+func (iu *ImageUploader) UploadImages(bundlePath string) ([]string, error) {
+	sourceImages, err := iu.loadImageBundle(bundlePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load images from %s: %w", bundlePath, err)
+	}
+
+	targetImages := make([]string, len(sourceImages))
+
+	for i, image := range sourceImages {
+		newImage, err := iu.retagImage(image)
+		if err != nil {
+			return nil, fmt.Errorf("failed to retag image %s: %w", image, err)
+		}
+
+		targetImages[i] = newImage
+	}
+
+	for _, target := range targetImages {
+		if err := iu.pushImage(target); err != nil {
+			return nil, fmt.Errorf("failed to push image %s: %w", target, err)
+		}
+	}
+
+	return targetImages, nil
+}

--- a/pkg/docker/uploader.go
+++ b/pkg/docker/uploader.go
@@ -10,15 +10,18 @@ import (
 	"github.com/iyehuda/bring/pkg/utils/commands"
 )
 
+// ImageRetagger is an interface that is able to get an image name and return a modified version of it.
 type ImageRetagger interface {
 	Retag(string) string
 }
 
+// ImageUploader is able to load an image bundle, retag its contents and upload it to a specified registry target.
 type ImageUploader struct {
 	retagger ImageRetagger
 	runner   commands.Runner
 }
 
+// NewImageUploader creates a new ImageUploader with a retagger and command runner.
 func NewImageUploader(retagger ImageRetagger, runner commands.Runner) *ImageUploader {
 	return &ImageUploader{retagger: retagger, runner: runner}
 }
@@ -64,6 +67,8 @@ func (iu *ImageUploader) pushImage(image string) error {
 	return nil
 }
 
+// UploadImages takes an image bundle path, loads its images, retag them using the uploader retagger
+// and uploads them to the uploader destination.
 func (iu *ImageUploader) UploadImages(bundlePath string) ([]string, error) {
 	sourceImages, err := iu.loadImageBundle(bundlePath)
 	if err != nil {

--- a/pkg/executils/commands.go
+++ b/pkg/executils/commands.go
@@ -1,4 +1,4 @@
-package commands
+package executils
 
 import "os/exec"
 

--- a/pkg/testutils/commands.go
+++ b/pkg/testutils/commands.go
@@ -1,4 +1,4 @@
-package tests
+package testutils
 
 import (
 	"os/exec"
@@ -14,7 +14,7 @@ type MockCommandRunner struct {
 func (r *MockCommandRunner) Run(cmd *exec.Cmd) error {
 	args := r.Called(cmd)
 
-	return args.Error(0)
+	return args.Error(0) //nolint:wrapcheck
 }
 
 type CommandPredicate func(cmd *exec.Cmd) bool

--- a/scripts/download-images.sh
+++ b/scripts/download-images.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TESTDATA=$(realpath $(dirname $0)/../integration/testdata)
+IMAGES_DIR=${TESTDATA}/images/
+FIRST=busybox:1.35.0
+SECOND=alpine:3.16.2
+
+mkdir -p $IMAGES_DIR
+
+echo "Downloading images..."
+docker pull $FIRST
+docker pull $SECOND
+
+echo "Saving images..."
+docker save $FIRST -o $IMAGES_DIR/single.tar
+docker save $FIRST $SECOND -o $IMAGES_DIR/multiple.tar
+
+echo "This is not a tar file..." > $IMAGES_DIR/invalid.tar


### PR DESCRIPTION
# Add docker uplaod command

## Summary
Introduce a new `bring docker upload` command.
This command takes an image bundle file that originated in `bring docker download` command, and deploys its content to specified registry.

Resolves #3

## Examples
Exmaple of using this command:
```bash
# First, download some images
bring docker download alpine:3.16.2 quay.io/iyehuda/redis:7.0.5-alpine --to images.tar

# Next, upload the bundle to specified registry (optionally, subfolder in it)
bring docker upload images.tar --to myregistry.example.com/myaccount
```

## Notes
Not every registry supports nested repository path (e.g. `registry.com/some/path/image:tag`).
Known supporting registries are:
* Vanilla docker registry (`registry:2` from Docker Hub)
* JFrog Artifactory (which is used for integration tests

Exmaple of not supporting registries:
* Docker Hub
* Google Container Registry (GCR)
* GitHub Container Registry (GHCR)
